### PR TITLE
Fix function calls.

### DIFF
--- a/src/codegen_expr.c
+++ b/src/codegen_expr.c
@@ -184,23 +184,9 @@ int codegen_expression(ast_node_t *node, LLVMBuilderRef builder,
             }
         }
 
-        LLVMTypeRef callee_type = LLVMTypeOf(callee);
-        if (!callee_type) {
-            error("codegen: failed to get type of callee");
-            free(args);
-            return -1;
-        }
-
-        if (LLVMGetTypeKind(callee_type) != LLVMPointerTypeKind) {
-            error("codegen: expected a function pointer type, got %d",
-                  LLVMGetTypeKind(callee_type));
-            free(args);
-            return -1;
-        }
-
-        LLVMTypeRef func_type = LLVMGetElementType(callee_type);
+        LLVMTypeRef func_type = LLVMGlobalGetValueType(callee);
         if (!func_type) {
-            error("codegen: failed to get type of function");
+            error("codegen: failed to get type of callee");
             free(args);
             return -1;
         }


### PR DESCRIPTION
Need to use `LLVMGlobalGetValueType` instead of `LLVMTypeOf` for getting the type of a function, since functions are always `GlobalValue` which are of type `ptr` (which is opaque). Using `GlobalValue::getValueType()` fixes the issue.

A simple `cloak` program like below is able to successfully compile with this change:

```
fn foo(): i32 {
    return 1;
}

fn main(): i32 {
    return foo();
}
```